### PR TITLE
Add option to append Migrated-From: suffix to tickets

### DIFF
--- a/trac2github.php
+++ b/trac2github.php
@@ -46,6 +46,10 @@ $skip_comments = true;
 $comments_offset = 0; // Start at this offset if limit > 0
 $comments_limit = 0; // Max comments per run if > 0
 
+// Whether to add a "Migrated-From:" suffix to each issue's body
+$add_migrated_suffix = false;
+$trac_url = 'http://my.domain/trac/env';
+
 // Paths to milestone/ticket cache if you run it multiple times with skip/offset
 $save_milestones = '/tmp/trac_milestones.list';
 $save_tickets = '/tmp/trac_tickets.list';
@@ -187,7 +191,7 @@ if (!$skip_tickets) {
         // There is a strange issue with summaries containing percent signs...
 		$resp = github_add_issue(array(
 			'title' => preg_replace("/%/", '[pct]', $row['summary']),
-			'body' => $body,
+			'body' => body_with_possible_suffix($body, $row['id']),
 			'assignee' => isset($users_list[$row['owner']]) ? $users_list[$row['owner']] : $row['owner'],
 			'milestone' => $milestones[crc32($row['milestone'])],
 			'labels' => $ticketLabels
@@ -307,6 +311,12 @@ function translate_markup($data) {
 
     // Possibly translate other markup as well?
     return $data;
+}
+
+function body_with_possible_suffix($body, $id) {
+	global $add_migrated_suffix, $trac_url;
+	if (!$add_migrated_suffix) return $body;
+	return "$body\n\nMigrated-From: $trac_url/ticket/$id";
 }
 
 ?>


### PR DESCRIPTION
In cases where the old Trac remains available, it can be nice to have a link back to the old Trac system to know where each issue came from. The syntax "Migrated-From:" was chosen because it is similar to how extra metadata tags on Git commit messages work, but of course anyone is free to hack it to whatever they want if they desire something else.
