### PR TITLE
Multiple small improvements:

### DIFF
--- a/README
+++ b/README
@@ -6,6 +6,6 @@ Features:
 - Slows down to match the 60 requests per second API limit rate
 
 Usage:
-1. Edit the configuration variables in the file above the DO NOT EDIT BELOW comment.
+1. Edit the configuration variables in the file above the DO NOT EDIT BELOW comment or use the external configuration file, trac2github.cfg.
 2. Run it from shell, e.g.:
 $ php trac2github.php

--- a/trac2github.cfg
+++ b/trac2github.cfg
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @package trac2github
+ * @version 1.1
+ * @author Vladimir Sibirov
+ * @author Lukas Eder
+ * @copyright (c) Vladimir Sibirov 2011
+ * @license BSD
+ */
+
+$username   = 'Put your github username here';
+$password   = 'Put your github password here';
+$project    = 'Organization or User name';
+$repo       = 'Organization or User name';
+
+// All users must be valid github logins!
+$users_list = array(
+	'TracUsermame' => 'GithubUsername',
+	'Trustmaster' => 'trustmaster',
+	'John.Done' => 'johndoe'
+);
+
+// The PDO driver name to use.
+// Options are: 'mysql', 'sqlite', 'pgsql'
+$pdo_driver = 'mysql';
+
+// MySQL connection info
+$mysqlhost_trac     = 'Trac MySQL host';
+$mysqluser_trac     = 'Trac MySQL user';
+$mysqlpassword_trac = 'Trac MySQL password';
+$mysqldb_trac       = 'Trac MySQL database name';
+
+// Path to SQLite database file
+$sqlite_trac_path = '/path/to/trac.db';
+
+// Postgresql connection info
+$pgsql_host     = 'localhost';
+$pgsql_dbname   = 'Postgres database name';
+$pgsql_user     = 'Postgres user name';
+$pgsql_password = 'Postgres password';
+
+// Do not convert milestones at this run
+$skip_milestones = false;
+
+// Do not convert labels at this run
+$skip_labels = false;
+
+// Do not convert tickets
+$skip_tickets   = false;
+$ticket_offset  = 0; // Start at this offset if limit > 0
+$ticket_limit   = 0; // Max tickets per run if > 0
+
+// Do not convert comments
+$skip_comments   = true;
+$comments_offset = 0; // Start at this offset if limit > 0
+$comments_limit  = 0; // Max comments per run if > 0
+
+// Whether to add a "Migrated-From:" suffix to each issue's body
+$add_migrated_suffix = false;
+$trac_url = 'http://my.domain/trac/env';
+
+// Paths to milestone/ticket cache if you run it multiple times with skip/offset
+$save_milestones = '/tmp/trac_milestones.list';
+$save_tickets = '/tmp/trac_tickets.list';
+
+// Set this to true if you want to see the JSON output sent to GitHub
+$verbose = false;
+
+// Uncomment to refresh cache
+// @unlink($save_milestones);
+// @unlink($save_labels);
+// @unlink($save_tickets);
+
+?>


### PR DESCRIPTION
- Added optional configuration file, trac2github.cfg
- Milestone can now be empty
- Information about original reporter/author/time added to the issue text

The configuration file was really only added to make it simpler to update the script code and then check it in. If the configuration is in the same file I have to undo the configuration before committing.

The information added to the top of each issue/comment looks like:
**Reported by sm0svx on 2014-06-29 20:30 UTC**
An example of how it might look in reality can be seen [here](https://github.com/sm0svx/svxlink/issues/22).
