### PR TITLE
Obfuscate reporters e-mails

### DIFF
--- a/trac2github.php
+++ b/trac2github.php
@@ -36,9 +36,10 @@ $mysqldb_trac       = 'Trac MySQL database name';
 $sqlite_trac_path = '/path/to/trac.db';
 
 // Postgresql connection info
-$pgsql_host     = 'localhost';
-$pgsql_dbname   = 'Postgres database name';
-$pgsql_user     = 'Postgres user name';
+$pgsql_host = 'localhost';
+$pgsql_port  = '5432';
+$pgsql_dbname = 'Postgres database name';
+$pgsql_user = 'Postgres user name';
 $pgsql_password = 'Postgres password';
 
 // Do not convert milestones at this run
@@ -101,7 +102,7 @@ switch ($pdo_driver) {
 		break;
 
 	case 'pgsql':
-		$trac_db = new PDO("pgsql:host=$pgsql_host;dbname=$pgsql_dbname;user=$pgsql_user;password=$pgsql_password");
+		$trac_db = new PDO("pgsql:host=$pgsql_host;port=$pgsql_port;dbname=$pgsql_dbname;user=$pgsql_user;password=$pgsql_password");
 		break;
 
 	default:


### PR DESCRIPTION
Sometimes, Trac users leave their a-mail address as reporter string, we must obfuscate them to avoid to make them available to spam attackers when migrating from Trac to GitHub.
