### PR TITLE
Added option to restrict selection of tickets to certain components.

### DIFF
--- a/trac2github.cfg
+++ b/trac2github.cfg
@@ -20,6 +20,10 @@ $users_list = array(
 	'John.Done' => 'johndoe'
 );
 
+//Restrict to certain components (null or Array with components name).
+$use_components = null;
+//$use_components = array('ios_app');
+
 // The PDO driver name to use.
 // Options are: 'mysql', 'sqlite', 'pgsql'
 $pdo_driver = 'mysql';


### PR DESCRIPTION
In our Trac we collected tickets that referred to different git repos and separated them trough trac "components" (i.e. one for our iOs-app, one for our Android-app etc.). When transferring the trac tickets to github issues, we only wanted to transfer tickets from certain components. Therefore I added the option to restrict the selected tickets to certain components. 