### PR TITLE
Ticket history migration and few other features

### DIFF
--- a/trac2github.cfg
+++ b/trac2github.cfg
@@ -65,15 +65,12 @@ $add_migrated_suffix = false;
 $trac_url = 'http://my.domain/trac/env';
 
 // Paths to milestone/ticket cache if you run it multiple times with skip/offset
-$save_milestones = '/tmp/trac_milestones.list';
-$save_tickets = '/tmp/trac_tickets.list';
+$save_tickets = './trac_tickets.list';
 
 // Set this to true if you want to see the JSON output sent to GitHub
 $verbose = false;
 
 // Uncomment to refresh cache
-// @unlink($save_milestones);
-// @unlink($save_labels);
 // @unlink($save_tickets);
 
 ?>

--- a/trac2github.cfg
+++ b/trac2github.cfg
@@ -66,6 +66,7 @@ $remap_labels = array(
 $skip_tickets   = false;
 $ticket_offset  = 0; // Start at this offset if limit > 0
 $ticket_limit   = 0; // Max tickets per run if > 0
+$ticket_try_preserve_numbers  = false;
 
 // Do not convert comments
 $skip_comments   = true;

--- a/trac2github.cfg
+++ b/trac2github.cfg
@@ -68,8 +68,8 @@ $ticket_offset  = 0; // Start at this offset if limit > 0
 $ticket_limit   = 0; // Max tickets per run if > 0
 $ticket_try_preserve_numbers  = false;
 
-// Do not convert comments
-$skip_comments   = true;
+// Do not convert comments nor ticket history
+$skip_comments   = false;
 $comments_offset = 0; // Start at this offset if limit > 0
 $comments_limit  = 0; // Max comments per run if > 0
 

--- a/trac2github.cfg
+++ b/trac2github.cfg
@@ -50,6 +50,18 @@ $skip_milestones = false;
 // Do not convert labels at this run
 $skip_labels = false;
 
+$remap_labels = array(
+	'T: defect' => 'bug',
+	'T: feature' => 'enhancement',
+	'T: enhancement' => 'enhancement',
+	'R: implemented' => NULL,
+	'R: fixed' => NULL,
+	'R: invalid' => 'invalid',
+	'R: wontfix' => 'wontfix',
+	'R: worksforme' => 'worksforme',
+	'R: notanissue' => 'notanissue',
+);
+
 // Do not convert tickets
 $skip_tickets   = false;
 $ticket_offset  = 0; // Start at this offset if limit > 0

--- a/trac2github.php
+++ b/trac2github.php
@@ -293,7 +293,6 @@ if (!$skip_tickets) {
 		$timestamp = date("j M Y H:i e", $row['time']/($time_in_us? 1000000:1));
 		$body = '**Reported by ' . obfuscate_email($row['reporter']) . ' on ' . $timestamp . "**\n" . $body;
 
-		// There is a strange issue with summaries containing percent signs...
 		if (empty($row['milestone'])) {
 			$milestone = NULL;
 		} else {
@@ -305,7 +304,7 @@ if (!$skip_tickets) {
 			$assignee = NULL;
 		}
 		$resp = github_add_issue(array(
-			'title' => preg_replace("/%/", '[pct]', $row['summary']),
+			'title' => $row['summary'],
 			'body' => body_with_possible_suffix($body, $row['id']),
 			'assignee' => $assignee,
 			'milestone' => $milestone,

--- a/trac2github.php
+++ b/trac2github.php
@@ -51,6 +51,8 @@ $skip_milestones = false;
 // Do not convert labels at this run
 $skip_labels = false;
 
+$remap_labels = array();
+
 // Do not convert tickets
 $skip_tickets   = false;
 $ticket_offset  = 0; // Start at this offset if limit > 0
@@ -196,6 +198,13 @@ if (!$skip_labels) {
 	}
 	foreach ($res->fetchAll() as $row) {
 		$label_name = $row['label_type'] . ': ' . $row['name'];
+		if (array_key_exists($label_name, $remap_labels)) {
+			$label_name = $remap_labels[$label_name];
+		}
+		if (empty($label_name)) {
+			$labels[$row['label_type']][crc32($row['name'])] = NULL;
+			continue;
+		}
 		if (in_array($label_name, $existing_labels)) {
 			echo "Label {$row['name']} already exists\n";
 			$labels[$row['label_type']][crc32($row['name'])] = $label_name;

--- a/trac2github.php
+++ b/trac2github.php
@@ -119,7 +119,7 @@ switch ($pdo_driver) {
 $trac_db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 // Boolean used to divide times by 1000000 when using Postgres where times are stored in microsecs (bigint)
-$postgres=($pdo_driver == 'pgsql');
+$time_in_us=($pdo_driver == 'pgsql' || $pdo_driver == 'sqlite');
 
 echo "Connected to Trac\n";
 
@@ -143,7 +143,7 @@ if (!$skip_milestones) {
 			continue;
 		}
 		//$milestones[$row['name']] = ++$mnum;
-		$epochInSecs = (int) ($row['due']/($postgres? 1000000:1));
+		$epochInSecs = (int) ($row['due']/($time_in_us? 1000000:1));
 		echo "due : ".date('Y-m-d\TH:i:s\Z', $epochInSecs)."\n";
 		$resp = github_add_milestone(array(
 			'title' => $row['name'],
@@ -257,7 +257,7 @@ if (!$skip_tickets) {
 		}
 
 		$body = make_body($row['description']);
-		$timestamp = date("j M Y H:i e", $row['time']/($postgres? 1000000:1));
+		$timestamp = date("j M Y H:i e", $row['time']/($time_in_us? 1000000:1));
 		$body = '**Reported by ' . obfuscate_email($row['reporter']) . ' on ' . $timestamp . "**\n" . $body;
 
 		// There is a strange issue with summaries containing percent signs...


### PR DESCRIPTION
Features implemented here:
* migration of ticket history, including state (closing, reopening), type, priority and so on
* download existing labels and milestones from github - no longer rely on local file from previous run
* try to preserve ticket numbers (optional) - create placeholders for missing tickets
* abort on errors

The modified version was used to migrate Qubes OS tickets: https://github.com/QubesOS/qubes-issues/issues, you can take a look how migrated tickets look like now.